### PR TITLE
Fix audio examples

### DIFF
--- a/Circuit_Playground_Express/Circuit_Playground_Express_Examples/play_wav.py
+++ b/Circuit_Playground_Express/Circuit_Playground_Express_Examples/play_wav.py
@@ -5,13 +5,14 @@ Once the file is copied, this example plays a wav file using the speaker on the 
 square located next to the picture of musical notes on the board."""
 import board
 import audioio
+import audiocore
 import digitalio
 
 speaker_enable = digitalio.DigitalInOut(board.SPEAKER_ENABLE)
 speaker_enable.switch_to_output(value=True)
 
 data = open("dip.wav", "rb")
-wav = audioio.WaveFile(data)
+wav = audiocore.WaveFile(data)
 a = audioio.AudioOut(board.SPEAKER)
 
 print("Playing file.")

--- a/Circuit_Playground_Express/Circuit_Playground_Express_Examples/play_wav.py
+++ b/Circuit_Playground_Express/Circuit_Playground_Express_Examples/play_wav.py
@@ -1,5 +1,5 @@
 """THIS EXAMPLE REQUIRES A WAV FILE FROM THE ADDITIONAL_CONTENT FOLDER IN THE PyCon2019 REPO!
-Copy the "dip.wav" file to your CIRCUITPY drive.
+Copy the "space.wav" file to your CIRCUITPY drive.
 
 Once the file is copied, this example plays a wav file using the speaker on the CPX, the grey
 square located next to the picture of musical notes on the board."""
@@ -11,7 +11,7 @@ import digitalio
 speaker_enable = digitalio.DigitalInOut(board.SPEAKER_ENABLE)
 speaker_enable.switch_to_output(value=True)
 
-data = open("dip.wav", "rb")
+data = open("space.wav", "rb")
 wav = audiocore.WaveFile(data)
 a = audioio.AudioOut(board.SPEAKER)
 

--- a/Circuit_Playground_Express/Circuit_Playground_Express_cpx_Library_Examples/cpx_play_file.py
+++ b/Circuit_Playground_Express/Circuit_Playground_Express_cpx_Library_Examples/cpx_play_file.py
@@ -1,7 +1,7 @@
 """THIS EXAMPLE REQUIRES A WAV FILE FROM THE ADDITIONAL_CONTENT FOLDER IN THE PyCon2019 REPO!
-Copy the "dip.wav" file to your CIRCUITPY drive.
+Copy the "space.wav" file to your CIRCUITPY drive.
 
 Once the file is copied, this example plays a wav file!"""
 from adafruit_circuitplayground.express import cpx
 
-cpx.play_file("dip.wav")
+cpx.play_file("space.wav")

--- a/Circuit_Playground_Express/Circuit_Playground_Express_cpx_Library_Examples/cpx_play_file_buttons.py
+++ b/Circuit_Playground_Express/Circuit_Playground_Express_cpx_Library_Examples/cpx_play_file_buttons.py
@@ -1,11 +1,11 @@
 """THIS EXAMPLE REQUIRES A WAV FILE FROM THE ADDITIONAL_CONTENT FOLDER IN THE PyCon2019 REPO!
-Copy the "dip.wav" and "rise.wav" files to your CIRCUITPY drive.
+Copy the "space.wav" and "rise.wav" files to your CIRCUITPY drive.
 
 Once the files are copied, this example plays a different wav file for each button pressed!"""
 from adafruit_circuitplayground.express import cpx
 
 while True:
     if cpx.button_a:
-        cpx.play_file("dip.wav")
+        cpx.play_file("space.wav")
     if cpx.button_b:
         cpx.play_file("rise.wav")


### PR DESCRIPTION
Fixes existing examples to use `audiocore` module (for CircuitPython 8 compatibility), as well as specify a WAV file in the repo.